### PR TITLE
Add support for Boost Serialization of dynamic_bitset<>

### DIFF
--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -348,6 +348,10 @@ public:
 
 #endif
 
+public:
+    // forward declaration for optional zero-copy serialization support
+    class serialize_impl;
+    friend class serialize_impl;
 
 private:
     BOOST_STATIC_CONSTANT(block_width_type, ulong_width = std::numeric_limits<unsigned long>::digits);

--- a/include/boost/dynamic_bitset/serialization.hpp
+++ b/include/boost/dynamic_bitset/serialization.hpp
@@ -1,0 +1,46 @@
+// -----------------------------------------------------------
+//
+// Copyright (c) 2015 Seth Heeren
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+// -----------------------------------------------------------
+
+#ifndef BOOST_DYNAMIC_BITSET_SERIALIZATION_HPP
+#define BOOST_DYNAMIC_BITSET_SERIALIZATION_HPP
+
+#include "boost/dynamic_bitset/dynamic_bitset.hpp"
+#include <boost/serialization/vector.hpp>
+
+namespace boost {
+
+    // implementation for optional zero-copy serialization support
+    template <typename Block, typename Allocator>
+        class dynamic_bitset<Block, Allocator>::serialize_impl
+        {
+            public:
+                template <typename Ar> 
+                static void serialize(Ar& ar, dynamic_bitset<Block, Allocator>& bs, unsigned) {
+                    ar & serialization::make_nvp("m_num_bits", bs.m_num_bits)
+                       & serialization::make_nvp("m_bits", bs.m_bits);
+                }
+        };
+
+}
+
+// ADL hook to Boost Serialization library
+namespace boost {
+    namespace serialization {
+
+        template <typename Ar, typename Block, typename Allocator>
+            void serialize(Ar& ar, dynamic_bitset<Block, Allocator>& bs, unsigned version) {
+                dynamic_bitset<Block, Allocator>::serialize_impl::serialize(ar, bs, version);
+            }
+
+    } // namespace serialization
+} // namespace boost
+
+#endif // include guard
+

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -11,4 +11,6 @@ test-suite dynamic_bitset :
     [ run dyn_bitset_unit_tests2.cpp ]
     [ run dyn_bitset_unit_tests3.cpp ]
     [ run dyn_bitset_unit_tests4.cpp ]
+    [ run dyn_bitset_unit_tests5.cpp /boost/serialization//boost_serialization
+       : : : <define>_SCL_SECURE_NO_WARNINGS=1 ]
     ;

--- a/test/dyn_bitset_unit_tests5.cpp
+++ b/test/dyn_bitset_unit_tests5.cpp
@@ -1,0 +1,111 @@
+// -----------------------------------------------------------
+//              Copyright (c) 2001 Jeremy Siek
+//           Copyright (c) 2003-2006 Gennaro Prota
+//
+// Copyright (c) 2015 Seth Heeren
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+// -----------------------------------------------------------
+
+#include "boost/config.hpp"
+#if !defined (BOOST_NO_STRINGSTREAM)
+# include <sstream>
+#endif
+
+#include "bitset_test.hpp"
+#include "boost/dynamic_bitset/serialization.hpp"
+#include "boost/detail/workaround.hpp"
+
+
+// Codewarrior 8.3 for Win fails without this.
+// Thanks Howard Hinnant ;)
+#if defined __MWERKS__ && BOOST_WORKAROUND(__MWERKS__, <= 0x3003) // 8.x
+# pragma parse_func_templ off
+#endif
+
+
+#if defined BOOST_NO_STD_WSTRING || defined BOOST_NO_STD_LOCALE
+# define BOOST_DYNAMIC_BITSET_NO_WCHAR_T_TESTS
+#endif
+
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <sstream>
+
+namespace {
+    template <typename Block>
+        struct SerializableType {
+            boost::dynamic_bitset<Block> x;
+
+          private:
+            friend class boost::serialization::access;
+            template <class Archive> void serialize(Archive &ar, const unsigned int) {
+                ar & BOOST_SERIALIZATION_NVP(x);
+            }
+        };
+
+    template <typename Block, typename IArchive, typename OArchive>
+        void test_serialization( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
+        {
+            SerializableType<Block> a;
+
+            for (int i=0; i<128; ++i)
+                a.x.resize(11*i, i%2);
+
+#if !defined (BOOST_NO_STRINGSTREAM)
+            std::stringstream ss;
+
+            // test serialization
+            {
+                OArchive oa(ss);
+                oa << BOOST_SERIALIZATION_NVP(a);
+            }
+
+            // test de-serialization
+            {
+                IArchive ia(ss);
+                SerializableType<Block> b;
+                ia >> BOOST_SERIALIZATION_NVP(b);
+
+                assert(a.x == b.x);
+            }
+#else
+#           error "TODO implement file-based test path?"
+#endif
+        }
+
+    template <typename Block>
+        void test_binary_archive( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) ) {
+            test_serialization<Block, boost::archive::binary_iarchive, boost::archive::binary_oarchive>();
+        }
+
+    template <typename Block>
+        void test_xml_archive( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) ) {
+            test_serialization<Block, boost::archive::xml_iarchive, boost::archive::xml_oarchive>();
+        }
+}
+
+template <typename Block>
+void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
+{
+    test_binary_archive<Block>();
+    test_xml_archive<Block>();
+}
+
+int test_main(int, char*[])
+{
+    run_test_cases<unsigned char>();
+    run_test_cases<unsigned short>();
+    run_test_cases<unsigned int>();
+    run_test_cases<unsigned long>();
+# ifdef BOOST_HAS_LONG_LONG
+    run_test_cases< ::boost::ulong_long_type>();
+# endif
+
+    return 0;
+}


### PR DESCRIPTION
Serialization using the public interface isn't optimal as `to_block_range()`/`from_block_range()` require copying of `m_bits` (and subsequent `resize()`).

I added a generic implementation to Boost Dynamic Bitset. The changes merge cleanly against develop or master (1_58_0).
## Changes

Implementation added with 
- Minimal intrusiveness, only a nested friend (`class serialization_impl;`) has been forward declared to "key-hole" the required friend access through
- This class, as well as the actual ADL hook for Boost Serialization are implemented in a separate header (`dynamic_bitset/serialization.hpp`, similar to other boost libraries with serialization support).
- This means that zero dependencies on Boost Serialization stuff exists unless `boost/dynamic_bitset/serialization.hpp` is actually included
- Zero copy is achieved (leveraging `std::vector<Block>`'s builtin support in Boost Serialization)
- Supports archives that use name-value pairs (like xml_oarchive)
## Tests

The second commit in the pull request adds tests for this feature. I'm not sure how to add the `dyn_bitset_unit_tests5.cpp` to the Jamfile. I suppose something else must be done to ensure linking to Boost System and Boost Serialization. I have run the tests myself using a simple wrapper:

<!-- language: c++ -->

```
#include <modular-boost/libs/dynamic_bitset/dyn_bitset_unit_tests5.cpp>

int main() {
    test_main(0, nullptr);
}
```

Which can then be compiled and run with e.g.

```
g++ main.cpp -lboost_system -lboost_serialization && ./a.out
```

No output means no errors.
