### PR TITLE
fix wrong parameter type in constructor of dynamic_bitset::reference

### DIFF
--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -86,7 +86,7 @@ public:
 
 
         // the one and only non-copy ctor
-        reference(block_type & b, block_type pos)
+        reference(block_type & b, block_width_type pos)
             :m_block(b),
              m_mask( (assert(pos < bits_per_block),
                       block_type(1) << pos )


### PR DESCRIPTION
Signed-off-by: Daniela Engert <dani@ngrt.de>