### PR TITLE
Add set/reset/flip functions to change sequences

### DIFF
--- a/dynamic_bitset.html
+++ b/dynamic_bitset.html
@@ -201,6 +201,7 @@ public:
     dynamic_bitset&amp; <a href="#set3">set</a>(size_type n, size_type len, bool val = true);
     dynamic_bitset&amp; <a href="#set2">set</a>(size_type n, bool val = true);
     dynamic_bitset&amp; <a href="#set1">set</a>();
+    dynamic_bitset&amp; <a href="#reset3">reset</a>(size_type n, size_type len);
     dynamic_bitset&amp; <a href="#reset2">reset</a>(size_type n);
     dynamic_bitset&amp; <a href="#reset1">reset</a>();
     dynamic_bitset&amp; <a href="#flip2">flip</a>(size_type n);
@@ -1073,7 +1074,7 @@ dynamic_bitset&amp; <a id=
 <b>Precondition:</b> <tt>n + len &lt; this-&gt;size()</tt>.<br />
 <b>Effects:</b> Sets every bit indexed from <tt>n</tt> to
 <tt>n + len - 1</tt> inclusively if <tt>val</tt> is <tt>true</tt>, and
-clears them if <tt>val</tt> is false</tt>. <br />
+clears them if <tt>val</tt> is <tt>false</tt>. <br />
 <b>Returns:</b> <tt>*this</tt>
 
 <hr />
@@ -1087,6 +1088,17 @@ dynamic_bitset&amp; <a id=
 <tt>true</tt>, and clears bit <tt>n</tt> if <tt>val</tt> is
 <tt>false</tt>. <br />
  <b>Returns:</b> <tt>*this</tt>
+
+<hr />
+<pre>
+dynamic_bitset&amp; <a id=
+"reset3">reset</a>(size_type n, size_type len);
+</pre>
+
+<b>Precondition:</b> <tt>n + len &lt; this-&gt;size()</tt>.<br />
+<b>Effects:</b> Clears every bit indexed from <tt>n</tt> to
+<tt>n + len - 1</tt> inclusively.<br />
+<b>Returns:</b> <tt>*this</tt>
 
 <hr />
 <pre>

--- a/dynamic_bitset.html
+++ b/dynamic_bitset.html
@@ -204,6 +204,7 @@ public:
     dynamic_bitset&amp; <a href="#reset3">reset</a>(size_type n, size_type len);
     dynamic_bitset&amp; <a href="#reset2">reset</a>(size_type n);
     dynamic_bitset&amp; <a href="#reset1">reset</a>();
+    dynamic_bitset&amp; <a href="#flip3">flip</a>(size_type n, size_type len);
     dynamic_bitset&amp; <a href="#flip2">flip</a>(size_type n);
     dynamic_bitset&amp; <a href="#flip1">flip</a>();
     bool <a href="#test">test</a>(size_type n) const;
@@ -1107,6 +1108,16 @@ dynamic_bitset&amp; <a id="reset2">reset</a>(size_type n)
 
 <b>Precondition:</b> <tt>n &lt; this-&gt;size()</tt>.<br />
 <b>Effects:</b> Clears bit <tt>n</tt>.<br />
+<b>Returns:</b> <tt>*this</tt>
+
+<hr />
+<pre>
+dynamic_bitset&amp; <a id="flip3">flip</a>(size_type n, size_type len)
+</pre>
+
+<b>Precondition:</b> <tt>n + len &lt; this-&gt;size()</tt>.<br />
+<b>Effects:</b> Flips every bit indexed from <tt>n</tt> to
+<tt>n + len - 1</tt> inclusively.<br />
 <b>Returns:</b> <tt>*this</tt>
 
 <hr />

--- a/dynamic_bitset.html
+++ b/dynamic_bitset.html
@@ -8,6 +8,7 @@
               Copyright (c) 2003-2004, 2008 Gennaro Prota
                     Copyright (c) 2014 Ahmed Charles
                  Copyright (c) 2014 Riccardo Marcangelo
+                    Copyright (c) 2018 Evgeny Shulgin
 
        Distributed under the Boost Software License, Version 1.0.
           (See accompanying file LICENSE_1_0.txt or copy at
@@ -197,6 +198,7 @@ public:
     dynamic_bitset <a href="#op-sl">operator&lt;&lt;</a>(size_type n) const;
     dynamic_bitset <a href="#op-sr">operator&gt;&gt;</a>(size_type n) const;
 
+    dynamic_bitset&amp; <a href="#set3">set</a>(size_type n, size_type len, bool val = true);
     dynamic_bitset&amp; <a href="#set2">set</a>(size_type n, bool val = true);
     dynamic_bitset&amp; <a href="#set1">set</a>();
     dynamic_bitset&amp; <a href="#reset2">reset</a>(size_type n);
@@ -1061,6 +1063,18 @@ dynamic_bitset&amp; <a id="reset1">reset</a>()
 <b>Effects:</b> Clears every bit in this bitset.<br />
 <b>Returns:</b> <tt>*this</tt><br />
 <b>Throws:</b> nothing.
+
+<hr />
+<pre>
+dynamic_bitset&amp; <a id=
+"set3">set</a>(size_type n, size_type len, bool val = true);
+</pre>
+
+<b>Precondition:</b> <tt>n + len &lt; this-&gt;size()</tt>.<br />
+<b>Effects:</b> Sets every bit indexed from <tt>n</tt> to
+<tt>n + len - 1</tt> inclusively if <tt>val</tt> is <tt>true</tt>, and
+clears them if <tt>val</tt> is false</tt>. <br />
+<b>Returns:</b> <tt>*this</tt>
 
 <hr />
 <pre>

--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -283,6 +283,7 @@ public:
     dynamic_bitset& set(size_type n, size_type len, bool val = true);
     dynamic_bitset& set(size_type n, bool val = true);
     dynamic_bitset& set();
+    dynamic_bitset& reset(size_type n, size_type len);
     dynamic_bitset& reset(size_type n);
     dynamic_bitset& reset();
     dynamic_bitset& flip(size_type n);
@@ -1057,6 +1058,13 @@ dynamic_bitset<Block, Allocator>::set()
   std::fill(m_bits.begin(), m_bits.end(), static_cast<Block>(~0));
   m_zero_unused_bits();
   return *this;
+}
+
+template <typename Block, typename Allocator>
+inline dynamic_bitset<Block, Allocator>&
+dynamic_bitset<Block, Allocator>::reset(size_type pos, size_type len)
+{
+    return set(pos, len, false);
 }
 
 template <typename Block, typename Allocator>

--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -7,6 +7,7 @@
 // Copyright (c) 2014 Glen Joseph Fernandes
 // glenfe at live dot com
 // Copyright (c) 2014 Riccardo Marcangelo
+//             Copyright (c) 2018 Evgeny Shulgin
 //
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
@@ -279,6 +280,7 @@ public:
     dynamic_bitset operator>>(size_type n) const;
 
     // basic bit operations
+    dynamic_bitset& set(size_type n, size_type len, bool val = true);
     dynamic_bitset& set(size_type n, bool val = true);
     dynamic_bitset& set();
     dynamic_bitset& reset(size_type n);
@@ -369,6 +371,22 @@ private:
     static size_type block_index(size_type pos) BOOST_NOEXCEPT { return pos / bits_per_block; }
     static block_width_type bit_index(size_type pos) BOOST_NOEXCEPT { return static_cast<block_width_type>(pos % bits_per_block); }
     static Block bit_mask(size_type pos) BOOST_NOEXCEPT { return Block(1) << bit_index(pos); }
+    static Block bit_mask(size_type first, size_type last) BOOST_NOEXCEPT
+    {
+        Block res = (last == bits_per_block - 1)
+            ? static_cast<Block>(~0)
+            : ((Block(1) << (last + 1)) - 1);
+        res ^= (Block(1) << first) - 1;
+        return res;
+    }
+    static Block set_block_bits(Block block, size_type first,
+        size_type last, bool val) BOOST_NOEXCEPT
+    {
+        if (val)
+            return block | bit_mask(first, last);
+        else
+            return block & static_cast<Block>(~bit_mask(first, last));
+    }
 
     template <typename CharT, typename Traits, typename Alloc>
     void init_from_string(const std::basic_string<CharT, Traits, Alloc>& s,
@@ -958,6 +976,65 @@ dynamic_bitset<Block, Allocator>::operator>>(size_type n) const
 
 //-----------------------------------------------------------------------------
 // basic bit operations
+
+template <typename Block, typename Allocator>
+dynamic_bitset<Block, Allocator>&
+dynamic_bitset<Block, Allocator>::set(size_type pos,
+        size_type len, bool val)
+{
+    assert(pos + len <= m_num_bits);
+
+    // Do nothing in case of zero len
+    if (!len)
+        return *this;
+
+    // Use an additional asserts in order to detect size_type overflow
+    // For example: pos = 10, len = size_type_limit - 2, pos + len = 7
+    // In case of overflow, 'pos + len' is always smaller than 'len'
+    assert(pos + len >= len);
+
+    // Start and end blocks of the [pos; pos + len - 1] sequence
+    const int first_block = block_index(pos);
+    const int last_block = block_index(pos + len - 1);
+
+    const int first_bit_index = bit_index(pos);
+    const int last_bit_index = bit_index(pos + len - 1);
+
+    if (first_block == last_block) {
+        // Filling only a sub-block of a block
+        m_bits[first_block] = set_block_bits(m_bits[first_block],
+            first_bit_index, last_bit_index, val);
+    } else {
+        // Check if the corner blocks won't be fully filled with 'val'
+        const int first_block_shift = bit_index(pos) ? 1 : 0;
+        const int last_block_shift = (bit_index(pos + len - 1)
+            == bits_per_block - 1) ? 0 : 1;
+
+        // Blocks that will be filled with ~0 or 0 at once
+        const int first_full_block = first_block + first_block_shift;
+        const int last_full_block = last_block - last_block_shift;
+
+        if (first_full_block <= last_full_block) {
+            std::fill_n(m_bits.begin() + first_full_block,
+                    last_full_block - first_full_block + 1,
+                    val ? static_cast<Block>(~0) : Block(0));
+        }
+
+        // Fill the first block from the 'first' bit index to the end
+        if (first_block_shift) {
+            m_bits[first_block] = set_block_bits(m_bits[first_block],
+                first_bit_index, bits_per_block - 1, val);
+        }
+
+        // Fill the last block from the start to the 'last' bit index
+        if (last_block_shift) {
+            m_bits[last_block] = set_block_bits(m_bits[last_block],
+                0, last_bit_index, val);
+        }
+    }
+
+    return *this;
+}
 
 template <typename Block, typename Allocator>
 dynamic_bitset<Block, Allocator>&

--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -286,6 +286,7 @@ public:
     dynamic_bitset& reset(size_type n, size_type len);
     dynamic_bitset& reset(size_type n);
     dynamic_bitset& reset();
+    dynamic_bitset& flip(size_type n, size_type len);
     dynamic_bitset& flip(size_type n);
     dynamic_bitset& flip();
     bool test(size_type n) const;
@@ -410,6 +411,15 @@ private:
     inline static Block reset_block_full(Block) BOOST_NOEXCEPT
     {
         return 0;
+    }
+    inline static Block flip_block_partial(Block block, size_type first,
+        size_type last) BOOST_NOEXCEPT
+    {
+        return block ^ bit_mask(first, last);
+    }
+    inline static Block flip_block_full(Block block) BOOST_NOEXCEPT
+    {
+        return ~block;
     }
 
     template <typename CharT, typename Traits, typename Alloc>
@@ -1064,6 +1074,13 @@ dynamic_bitset<Block, Allocator>::reset()
 {
   std::fill(m_bits.begin(), m_bits.end(), Block(0));
   return *this;
+}
+
+template <typename Block, typename Allocator>
+dynamic_bitset<Block, Allocator>&
+dynamic_bitset<Block, Allocator>::flip(size_type pos, size_type len)
+{
+    return range_operation(pos, len, flip_block_partial, flip_block_full);
 }
 
 template <typename Block, typename Allocator>

--- a/test/bitset_test.hpp
+++ b/test/bitset_test.hpp
@@ -3,6 +3,7 @@
 //        Copyright (c) 2003-2006, 2008 Gennaro Prota
 //             Copyright (c) 2014 Ahmed Charles
 //            Copyright (c) 2014 Riccardo Marcangelo
+//             Copyright (c) 2018 Evgeny Shulgin
 //
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
@@ -616,6 +617,22 @@ struct bitset_test {
           BOOST_CHECK(lhs[I] == prev[I]);
     } else {
       // Not in range, doesn't satisfy precondition.
+    }
+  }
+
+  static void set_segment(const Bitset& b, std::size_t pos,
+    std::size_t len, bool value)
+  {
+    Bitset lhs(b);
+    std::size_t N = lhs.size();
+    Bitset prev(lhs);
+    lhs.set(pos, len, value);
+    for (std::size_t I = 0; I < N; ++I)
+    {
+      if (I < pos || I >= pos + len)
+        BOOST_CHECK(lhs[I] == prev[I]);
+      else
+        BOOST_CHECK(lhs[I] == value);
     }
   }
 

--- a/test/bitset_test.hpp
+++ b/test/bitset_test.hpp
@@ -717,6 +717,22 @@ struct bitset_test {
     }
   }
 
+  static void flip_segment(const Bitset& b, std::size_t pos,
+    std::size_t len)
+  {
+    Bitset lhs(b);
+    std::size_t N = lhs.size();
+    Bitset prev(lhs);
+    lhs.flip(pos, len);
+    for (std::size_t I = 0; I < N; ++I)
+    {
+      if (I < pos || I >= pos + len)
+        BOOST_CHECK(lhs[I] == prev[I]);
+      else
+        BOOST_CHECK(lhs[I] != prev[I]);
+    }
+  }
+
   // empty
   static void empty(const Bitset& b)
   {

--- a/test/bitset_test.hpp
+++ b/test/bitset_test.hpp
@@ -664,6 +664,22 @@ struct bitset_test {
     }
   }
 
+  static void reset_segment(const Bitset& b, std::size_t pos,
+    std::size_t len)
+  {
+    Bitset lhs(b);
+    std::size_t N = lhs.size();
+    Bitset prev(lhs);
+    lhs.reset(pos, len);
+    for (std::size_t I = 0; I < N; ++I)
+    {
+      if (I < pos || I >= pos + len)
+        BOOST_CHECK(lhs[I] == prev[I]);
+      else
+        BOOST_CHECK(!lhs[I]);
+    }
+  }
+
   static void operator_flip(const Bitset& b)
   {
     Bitset lhs(b);

--- a/test/dyn_bitset_unit_tests2.cpp
+++ b/test/dyn_bitset_unit_tests2.cpp
@@ -271,6 +271,33 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
     Tests::reset_one(b, long_string.size()/2);
   }
   //=====================================================================
+  // Test b.reset(pos, len)
+  { // case size is 1
+    boost::dynamic_bitset<Block> b(std::string("0"));
+    Tests::reset_segment(b, 0, 1);
+  }
+  { // case fill the whole set
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::reset_segment(b, 0, b.size());
+  }
+  { // case pos = size / 4, len = size / 2
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::reset_segment(b, b.size() / 4, b.size() / 2);
+  }
+  { // case pos = block_size / 2, len = size - block_size
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::reset_segment(b, boost::dynamic_bitset<Block>::bits_per_block / 2,
+            b.size() - boost::dynamic_bitset<Block>::bits_per_block);
+  }
+  { // case pos = 1, len = size - 2
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::reset_segment(b, 1, b.size() - 2);
+  }
+  { // case pos = 3, len = 7
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::reset_segment(b, 3, 7);
+  }
+  //=====================================================================
   // Test ~b
   {
     boost::dynamic_bitset<Block> b;

--- a/test/dyn_bitset_unit_tests2.cpp
+++ b/test/dyn_bitset_unit_tests2.cpp
@@ -339,6 +339,33 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
     boost::dynamic_bitset<Block> b(long_string);
     Tests::flip_one(b, long_string.size()/2);
   }
+  //=====================================================================
+  // Test b.flip(pos, len)
+  { // case size is 1
+    boost::dynamic_bitset<Block> b(std::string("0"));
+    Tests::flip_segment(b, 0, 1);
+  }
+  { // case fill the whole set
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::flip_segment(b, 0, b.size());
+  }
+  { // case pos = size / 4, len = size / 2
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::flip_segment(b, b.size() / 4, b.size() / 2);
+  }
+  { // case pos = block_size / 2, len = size - block_size
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::flip_segment(b, boost::dynamic_bitset<Block>::bits_per_block / 2,
+            b.size() - boost::dynamic_bitset<Block>::bits_per_block);
+  }
+  { // case pos = 1, len = size - 2
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::flip_segment(b, 1, b.size() - 2);
+  }
+  { // case pos = 3, len = 7
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::flip_segment(b, 3, 7);
+  }
 }
 
 int

--- a/test/dyn_bitset_unit_tests2.cpp
+++ b/test/dyn_bitset_unit_tests2.cpp
@@ -2,6 +2,7 @@
 //              Copyright (c) 2001 Jeremy Siek
 //           Copyright (c) 2003-2006 Gennaro Prota
 //             Copyright (c) 2014 Ahmed Charles
+//             Copyright (c) 2018 Evgeny Shulgin
 //
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
@@ -206,6 +207,40 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
     boost::dynamic_bitset<Block> b(long_string);
     Tests::set_one(b, long_string.size()/2, true);
     Tests::set_one(b, long_string.size()/2, false);
+  }
+  //=====================================================================
+  // Test b.set(pos, len)
+  { // case size is 1
+    boost::dynamic_bitset<Block> b(std::string("0"));
+    Tests::set_segment(b, 0, 1, true);
+    Tests::set_segment(b, 0, 1, false);
+  }
+  { // case fill the whole set
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::set_segment(b, 0, b.size(), true);
+    Tests::set_segment(b, 0, b.size(), false);
+  }
+  { // case pos = size / 4, len = size / 2
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::set_segment(b, b.size() / 4, b.size() / 2, true);
+    Tests::set_segment(b, b.size() / 4, b.size() / 2, false);
+  }
+  { // case pos = block_size / 2, len = size - block_size
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::set_segment(b, boost::dynamic_bitset<Block>::bits_per_block / 2,
+            b.size() - boost::dynamic_bitset<Block>::bits_per_block, true);
+    Tests::set_segment(b, boost::dynamic_bitset<Block>::bits_per_block / 2,
+            b.size() - boost::dynamic_bitset<Block>::bits_per_block, false);
+  }
+  { // case pos = 1, len = size - 2
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::set_segment(b, 1, b.size() - 2, true);
+    Tests::set_segment(b, 1, b.size() - 2, false);
+  }
+  { // case pos = 3, len = 7
+    boost::dynamic_bitset<Block> b(long_string);
+    Tests::set_segment(b, 3, 7, true);
+    Tests::set_segment(b, 3, 7, false);
   }
   //=====================================================================
   // Test b.reset()


### PR DESCRIPTION
Neither boost::dynamic_bitset nor vanilla std::bitset have the `fill()` function, and I propose to introduce this.
The point of the function is being used instead of loops with calling the `set(pos)` function.

Let's consider an example where we want either to set **1024** _consecutive_ bits or to reset them (taking as the fact that we don't change the whole bitset, only its part).
Using a cycle we do it using, well, **1024** operations. Though we could have done it using maximum 1024/64+1=**17** operations (considering the blocks as 64-bit integers) - setting the whole blocks between the first and the last bit, and optionally setting a suffix or a prefix of the first/last block respectively.

I also updated docs, tests. Yeah, the algorithm can look a bit complicated, and there are 2 helper functions added, but there's nothing hard at all.

Any suggestions, notes on possible performance improvement, arguments meaning (we change here [first; last], but can change [first;last) as it's more STL-like style); maybe naming too? I guess `fill(size_type first, size_type last, bool val = true);` could be named `set(size_type first, size_type last, bool val = true);` as well.