### PR TITLE
Disable hardware supported popcount on MSVC

### DIFF
--- a/include/boost/dynamic_bitset/detail/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/detail/dynamic_bitset.hpp
@@ -143,6 +143,12 @@ namespace boost {
      }
 
 #if ((defined(BOOST_MSVC) && (BOOST_MSVC >= 1600)) || (defined(__clang__) && defined(__c2__)) || (defined(BOOST_INTEL) && defined(_MSC_VER))) && (defined(_M_IX86) || defined(_M_X64))
+
+/*
+     per https://github.com/boostorg/dynamic_bitset/issues/33
+     this code does not support older cpus properly...
+     it needs to check for cpuid support to avoid undefined behavior
+
      template <>
      BOOST_FORCEINLINE std::size_t popcount<unsigned short>(unsigned short value) BOOST_NOEXCEPT
      {
@@ -162,6 +168,7 @@ namespace boost {
          return static_cast<std::size_t>(__popcnt64(value));
      }
 #endif
+ */
 
 #elif defined(BOOST_GCC) || defined(__clang__) || (defined(BOOST_INTEL) && defined(__GNUC__))
      template <>


### PR DESCRIPTION
- the new implementation failed to check for hardware support
- the behavior was undefined on platforms without SSE4

This fixes #33 

I will open another issue regarding proper implementation for MSVC.