### PR TITLE
Change to non-deprecated boost test usage

### DIFF
--- a/test/bitset_test.hpp
+++ b/test/bitset_test.hpp
@@ -27,8 +27,19 @@
 
 #include "boost/limits.hpp"
 #include "boost/dynamic_bitset/dynamic_bitset.hpp"
-#include "boost/test/minimal.hpp"
 #include "boost/filesystem.hpp"
+#include "boost/test/included/unit_test.hpp"
+#include "boost/mpl/list.hpp"
+
+typedef boost::mpl::list<
+  unsigned char,
+  unsigned short,
+  unsigned int,
+  unsigned long,
+# ifdef BOOST_HAS_LONG_LONG
+  ::boost::ulong_long_type
+# endif
+> dynamic_bitset_test_types;
 
 template <typename Block>
 inline bool nth_bit(Block num, std::size_t n)

--- a/test/dyn_bitset_unit_tests1.cpp
+++ b/test/dyn_bitset_unit_tests1.cpp
@@ -13,6 +13,8 @@
 //
 // -----------------------------------------------------------
 
+#define BOOST_TEST_MODULE dynamic_bitset_unit_1
+
 #include "bitset_test.hpp"
 #include "boost/dynamic_bitset/dynamic_bitset.hpp"
 #include "boost/limits.hpp"
@@ -135,9 +137,7 @@ void run_numeric_ctor_tests( BOOST_EXPLICIT_TEMPLATE_TYPE(Tests)
 
 }
 
-
-template <typename Block>
-void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
+BOOST_AUTO_TEST_CASE_TEMPLATE( run_test_cases, Block, dynamic_bitset_test_types )
 {
   typedef boost::dynamic_bitset<Block> bitset_type;
   typedef bitset_test<bitset_type> Tests;
@@ -517,18 +517,4 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
      bitset_test<Bitset>::max_size(b);
   }
 #endif
-}
-
-int
-test_main(int, char*[])
-{
-  run_test_cases<unsigned char>();
-  run_test_cases<unsigned short>();
-  run_test_cases<unsigned int>();
-  run_test_cases<unsigned long>();
-# ifdef BOOST_HAS_LONG_LONG
-  run_test_cases< ::boost::ulong_long_type>();
-# endif
-
-  return 0;
 }

--- a/test/dyn_bitset_unit_tests2.cpp
+++ b/test/dyn_bitset_unit_tests2.cpp
@@ -10,13 +10,14 @@
 //
 // -----------------------------------------------------------
 
+#define BOOST_TEST_MODULE dynamic_bitset_unit_2
+
 #include "bitset_test.hpp"
 #include "boost/dynamic_bitset/dynamic_bitset.hpp"
 #include "boost/config.hpp"
 
 
-template <typename Block>
-void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
+BOOST_AUTO_TEST_CASE_TEMPLATE( run_test_cases, Block, dynamic_bitset_test_types )
 {
   typedef boost::dynamic_bitset<Block> bitset_type;
   typedef bitset_test< bitset_type > Tests;
@@ -366,18 +367,4 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
     boost::dynamic_bitset<Block> b(long_string);
     Tests::flip_segment(b, 3, 7);
   }
-}
-
-int
-test_main(int, char*[])
-{
-  run_test_cases<unsigned char>();
-  run_test_cases<unsigned short>();
-  run_test_cases<unsigned int>();
-  run_test_cases<unsigned long>();
-# ifdef BOOST_HAS_LONG_LONG
-  run_test_cases< ::boost::ulong_long_type>();
-# endif
-
-  return 0;
 }

--- a/test/dyn_bitset_unit_tests3.cpp
+++ b/test/dyn_bitset_unit_tests3.cpp
@@ -10,14 +10,15 @@
 //
 // -----------------------------------------------------------
 
+#define BOOST_TEST_MODULE dynamic_bitset_unit_3
+
 #include <assert.h>
 #include "bitset_test.hpp"
 #include "boost/dynamic_bitset/dynamic_bitset.hpp"
 #include "boost/limits.hpp"
 #include "boost/config.hpp"
 
-template <typename Block>
-void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
+BOOST_AUTO_TEST_CASE_TEMPLATE( run_test_cases, Block, dynamic_bitset_test_types )
 {
   // a bunch of typedefs which will be handy later on
   typedef boost::dynamic_bitset<Block> bitset_type;
@@ -796,19 +797,4 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
     boost::dynamic_bitset<Block> lhs(long_string.size(), 1), rhs(long_string);
     Tests::operator_sub(lhs, rhs);
   }
-}
-
-
-int
-test_main(int, char*[])
-{
-  run_test_cases<unsigned char>();
-  run_test_cases<unsigned short>();
-  run_test_cases<unsigned int>();
-  run_test_cases<unsigned long>();
-# ifdef BOOST_HAS_LONG_LONG
-  run_test_cases< ::boost::ulong_long_type>();
-# endif
-
-  return 0;
 }

--- a/test/dyn_bitset_unit_tests4.cpp
+++ b/test/dyn_bitset_unit_tests4.cpp
@@ -8,6 +8,8 @@
 //
 // -----------------------------------------------------------
 
+#define BOOST_TEST_MODULE dynamic_bitset_test_4
+
 #include <fstream>
 #include <string>
 #include <cstddef>   // for std::size_t
@@ -56,10 +58,8 @@ std::wstring widen_string( const std::string & str,
 }
 #endif
 
-template <typename Block>
-void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
+BOOST_AUTO_TEST_CASE_TEMPLATE( run_test_cases, Block, dynamic_bitset_test_types )
 {
-
   typedef boost::dynamic_bitset<Block> bitset_type;
   typedef bitset_test<bitset_type> Tests;
 
@@ -320,19 +320,4 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
   // << Any other tests go here >>
   //         .....
 
-}
-
-
-int
-test_main(int, char*[])
-{
-  run_test_cases<unsigned char>();
-  run_test_cases<unsigned short>();
-  run_test_cases<unsigned int>();
-  run_test_cases<unsigned long>();
-# ifdef BOOST_HAS_LONG_LONG
-  run_test_cases< ::boost::ulong_long_type>();
-# endif
-
-  return 0;
 }

--- a/test/dyn_bitset_unit_tests5.cpp
+++ b/test/dyn_bitset_unit_tests5.cpp
@@ -10,6 +10,8 @@
 //
 // -----------------------------------------------------------
 
+#define BOOST_TEST_MODULE dynamic_bitset_unit_5
+
 #include "boost/config.hpp"
 #if !defined (BOOST_NO_STRINGSTREAM)
 # include <sstream>
@@ -90,22 +92,8 @@ namespace {
         }
 }
 
-template <typename Block>
-void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
+BOOST_AUTO_TEST_CASE_TEMPLATE( run_test_cases, Block, dynamic_bitset_test_types )
 {
     test_binary_archive<Block>();
     test_xml_archive<Block>();
-}
-
-int test_main(int, char*[])
-{
-    run_test_cases<unsigned char>();
-    run_test_cases<unsigned short>();
-    run_test_cases<unsigned int>();
-    run_test_cases<unsigned long>();
-# ifdef BOOST_HAS_LONG_LONG
-    run_test_cases< ::boost::ulong_long_type>();
-# endif
-
-    return 0;
 }

--- a/test/test_lowest_bit.cpp
+++ b/test/test_lowest_bit.cpp
@@ -17,8 +17,9 @@
 
 int main(int, char*[])
 {
-    for (boost::int32_t i = 1; i < 32; ++i) {
-	BOOST_TEST_EQ(i, boost::detail::lowest_bit(1u << i));
+    for (boost::int32_t i = 1; i < 32; ++i)
+    {
+        BOOST_TEST_EQ(i, boost::detail::lowest_bit(1u << i));
     }
 
     BOOST_TEST_EQ(2, boost::detail::lowest_bit(123456788));


### PR DESCRIPTION
The unit tests were using boost/test/minimal which is deprecated.