### PR TITLE
Make default constructor non-explicit

### DIFF
--- a/dynamic_bitset.html
+++ b/dynamic_bitset.html
@@ -144,8 +144,11 @@ public:
 
     typedef bool <a href="#const_reference">const_reference</a>;
 
+    <a href=
+"#cons0">dynamic_bitset</a>();
+
     explicit <a href=
-"#cons1">dynamic_bitset</a>(const Allocator&amp; alloc = Allocator());
+"#cons1">dynamic_bitset</a>(const Allocator&amp; alloc);
 
     explicit <a href=
 "#cons2">dynamic_bitset</a>(size_type num_bits, unsigned long value = 0,
@@ -570,19 +573,30 @@ The maximum value of <tt>size_type</tt>.
 <hr />
 <pre>
 <a id=
-"cons1">dynamic_bitset</a>(const Allocator&amp; alloc = Allocator())
+"cons0">dynamic_bitset</a>()
+</pre>
+
+<b>Effects:</b> Constructs a bitset of size zero. The allocator
+for this bitset is a default-constructed object of type
+<tt>Allocator</tt>.<br />
+ <b>Postconditions:</b> <tt>this-&gt;size() == 0</tt>.<br />
+ <b>Throws:</b> Nothing unless the default constructor of
+<tt>Allocator</tt> throws an exception.<br />
+ (Required by <a href=
+"https://boost.org/sgi/stl/DefaultConstructible.html">Default
+Constructible</a>.)
+
+<hr />
+<pre>
+<a id=
+"cons1">dynamic_bitset</a>(const Allocator&amp; alloc)
 </pre>
 
 <b>Effects:</b> Constructs a bitset of size zero. A copy of the
 <tt>alloc</tt> object will be used in subsequent bitset
 operations such as <tt>resize</tt> to allocate memory.<br />
  <b>Postconditions:</b> <tt>this-&gt;size() == 0</tt>.<br />
- <b>Throws:</b> An allocation error if memory is exhausted
-(<tt>std::bad_alloc</tt> if
-<tt>Allocator=std::allocator</tt>).<br />
- (Required by <a href=
-"https://boost.org/sgi/stl/DefaultConstructible.html">Default
-Constructible</a>.)
+ <b>Throws:</b> nothing.
 
 <hr />
 <pre>

--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -128,8 +128,10 @@ public:
     typedef bool const_reference;
 
     // constructors, etc.
+    dynamic_bitset() : m_num_bits(0) {}
+
     explicit
-    dynamic_bitset(const Allocator& alloc = Allocator());
+    dynamic_bitset(const Allocator& alloc);
 
     explicit
     dynamic_bitset(size_type num_bits, unsigned long value = 0,

--- a/test/dyn_bitset_unit_tests1.cpp
+++ b/test/dyn_bitset_unit_tests1.cpp
@@ -517,6 +517,11 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
      bitset_test<Bitset>::max_size(b);
   }
 #endif
+  // Test copy-initialize with default constructor
+  {
+    boost::dynamic_bitset<Block> b[1] = {};
+    (void)b;
+  }
 }
 
 int


### PR DESCRIPTION
IMHO, it is better to support copy-initialization with default constructor.

cf. LWG Issue 2193. Default constructors for standard library containers are explicit
link: https://wg21.cmeerw.net/lwg/issue2193