### PR TITLE
Make DynamicBitset no longer depend on Serialization

### DIFF
--- a/include/boost/dynamic_bitset/serialization.hpp
+++ b/include/boost/dynamic_bitset/serialization.hpp
@@ -12,7 +12,7 @@
 #define BOOST_DYNAMIC_BITSET_SERIALIZATION_HPP
 
 #include "boost/dynamic_bitset/dynamic_bitset.hpp"
-#include <boost/serialization/vector.hpp>
+#include <boost/core/nvp.hpp>
 
 namespace boost {
 
@@ -23,8 +23,8 @@ namespace boost {
             public:
                 template <typename Ar> 
                 static void serialize(Ar& ar, dynamic_bitset<Block, Allocator>& bs, unsigned) {
-                    ar & serialization::make_nvp("m_num_bits", bs.m_num_bits)
-                       & serialization::make_nvp("m_bits", bs.m_bits);
+                    ar & boost::make_nvp("m_num_bits", bs.m_num_bits)
+                       & boost::make_nvp("m_bits", bs.m_bits);
                 }
         };
 

--- a/test/dyn_bitset_unit_tests5.cpp
+++ b/test/dyn_bitset_unit_tests5.cpp
@@ -31,6 +31,7 @@
 # define BOOST_DYNAMIC_BITSET_NO_WCHAR_T_TESTS
 #endif
 
+#include <boost/serialization/vector.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>


### PR DESCRIPTION
Later I'll update the implementation in serialization.hpp to no longer require the user to include <boost/serialization/vector.hpp>.