### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/dynamic_bitset/config.hpp
+++ b/include/boost/dynamic_bitset/config.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace detail {
 #endif
 
 //
-#if (defined __BORLANDC__ && BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)))  \
+#if (defined BOOST_BORLANDC && BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)))  \
                              || (defined BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
 #define BOOST_DYNAMIC_BITSET_DONT_USE_FRIENDS
 #endif

--- a/test/bitset_test.hpp
+++ b/test/bitset_test.hpp
@@ -34,7 +34,7 @@ template <typename Block>
 inline bool nth_bit(Block num, std::size_t n)
 {
 #ifndef NDEBUG
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
   // Borland deduces Block as a const qualified type,
   // and thus finds numeric_limits<Block> to be zero :(
   //  (though not directly relevant here, see also

--- a/test/dyn_bitset_unit_tests4.cpp
+++ b/test/dyn_bitset_unit_tests4.cpp
@@ -191,7 +191,7 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
                   //       (in Tests::stream_extractor instantiation)
 
 
-#if !(defined __BORLANDC__     \
+#if !(defined BOOST_BORLANDC     \
       && BOOST_WORKAROUND(BOOST_RWSTD_VER, BOOST_TESTED_AT(0x20101)))
                                         // Borland 5.5.1 with RW library crashes
             // empty string


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.