### PR TITLE
Avoid using deprecated headers to silence compiler warnings.

### DIFF
--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <stdexcept>
 #include <algorithm>
+#include <iterator>     // used to implement append(Iter, Iter)
 #include <vector>
 #include <climits>      // for CHAR_BIT
 
@@ -43,12 +44,11 @@
 #include "boost/dynamic_bitset_fwd.hpp"
 #include "boost/dynamic_bitset/detail/dynamic_bitset.hpp"
 #include "boost/dynamic_bitset/detail/lowest_bit.hpp"
-#include "boost/detail/iterator.hpp" // used to implement append(Iter, Iter)
 #include "boost/move/move.hpp"
 #include "boost/limits.hpp"
 #include "boost/static_assert.hpp"
-#include "boost/utility/addressof.hpp"
-#include "boost/detail/no_exceptions_support.hpp"
+#include "boost/core/addressof.hpp"
+#include "boost/core/no_exceptions_support.hpp"
 #include "boost/throw_exception.hpp"
 #include "boost/functional/hash/hash.hpp"
 
@@ -247,7 +247,7 @@ public:
     {
         assert(first != last);
         block_width_type r = count_extra_bits();
-        std::size_t d = boost::detail::distance(first, last);
+        std::size_t d = std::distance(first, last);
         m_bits.reserve(num_blocks() + d);
         if (r == 0) {
             for( ; first != last; ++first)
@@ -267,7 +267,7 @@ public:
     void append(BlockInputIterator first, BlockInputIterator last) // strong guarantee
     {
         if (first != last) {
-            typename detail::iterator_traits<BlockInputIterator>::iterator_category cat;
+            typename std::iterator_traits<BlockInputIterator>::iterator_category cat;
             m_append(first, last, cat);
         }
     }


### PR DESCRIPTION
The warnings are generated by `boost/detail/iterator.hpp` and `boost/detail/no_exceptions_support.hpp`. Also, updated location of `addressof.hpp`.
