### PR TITLE
Update calc_num_blocks(). Avoid using modulo operator.

### DIFF
--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -2004,8 +2004,7 @@ template <typename Block, typename Allocator>
 inline typename dynamic_bitset<Block, Allocator>::size_type
 dynamic_bitset<Block, Allocator>::calc_num_blocks(size_type num_bits)
 {
-    return num_bits / bits_per_block
-           + static_cast<size_type>( num_bits % bits_per_block != 0 );
+    return (num_bits + bits_per_block - 1) / bits_per_block;
 }
 
 // gives a reference to the highest block


### PR DESCRIPTION
`num_bits + bits_per_block - 1` is unlikely to overflow. After the change, it could be a little faster.