### PR TITLE
Added dynamic_bitset(size_type, unsigned long long, const Allocator&) & to_ullong() and fixed typo

### DIFF
--- a/dynamic_bitset.html
+++ b/dynamic_bitset.html
@@ -152,7 +152,11 @@ public:
 
     explicit <a href=
 "#cons2">dynamic_bitset</a>(size_type num_bits, unsigned long value = 0,
-                            const Allocator&amp; alloc = Allocator());
+                            const Allocator&amp; alloc = Allocator()); (until C++11)
+
+    explicit <a href=
+"#cons2">dynamic_bitset</a>(size_type num_bits, unsigned long long value = 0,
+                            const Allocator&amp; alloc = Allocator()); (since C++11)
 
     template &lt;typename CharT, typename Traits, typename Alloc&gt;
     explicit <a href=
@@ -222,6 +226,8 @@ public:
     bool <a href="#const-bracket">operator[]</a>(size_type pos) const;
 
     unsigned long <a href="#to_ulong">to_ulong</a>() const;
+    unsigned long <a href="#to_ullong">to_ullong</a>() const; (since C++11)
+    
 
     size_type <a href="#size">size</a>() const noexcept;
     size_type <a href="#num_blocks">num_blocks</a>() const noexcept;
@@ -602,13 +608,18 @@ operations such as <tt>resize</tt> to allocate memory.<br />
 <pre>
 <a id="cons2">dynamic_bitset</a>(size_type num_bits,
                unsigned long value = 0,
-               const Allocator&amp; alloc = Allocator())
+               const Allocator&amp; alloc = Allocator()) (until C++11)
+
+<a id="cons2">dynamic_bitset</a>(size_type num_bits,
+               unsigned long long value = 0,
+               const Allocator&amp; alloc = Allocator()) (since C++11)
 </pre>
 
 <b>Effects:</b> Constructs a bitset from an integer. The first
 <tt>M</tt> bits are initialized to the corresponding bits in
 <tt>value</tt> and all other bits, if any, to zero (where <tt>M =
-min(num_bits, std::numeric_limits&lt;unsigned long&gt;::digits)</tt>). A copy of
+min(num_bits, std::numeric_limits&lt;unsigned long&gt;::digits) (until C++11)</tt> or <tt>M =
+min(num_bits, std::numeric_limits&lt;unsigned long long&gt;::digits) (since C++11)</tt>). A copy of
 the <tt>alloc</tt> object will be used in subsequent bitset
 operations such as <tt>resize</tt> to allocate memory. Note that, e.g., the
 following
@@ -1304,6 +1315,18 @@ unsigned long <a id="to_ulong">to_ulong</a>() const
 be represented in an <tt>unsigned long</tt>, i.e. if <tt>*this</tt> has
 any non-zero bit at a position <tt>&gt;=
 std::numeric_limits&lt;unsigned long&gt;::digits</tt>.
+
+<hr />
+<pre>
+unsigned long long <a id="to_ullong">to_ullong</a>() const (since C++11)
+</pre>
+
+<b>Returns:</b> The numeric value corresponding to the bits in <tt>*this</tt>.
+<br />
+<b>Throws:</b> <tt>std::overflow_error</tt> if that value is too large to
+be represented in an <tt>unsigned long long</tt>, i.e. if <tt>*this</tt> has
+any non-zero bit at a position <tt>&gt;=
+std::numeric_limits&lt;unsigned long long&gt;::digits</tt>.
 
 <hr />
 <pre>

--- a/include/boost/dynamic_bitset_fwd.hpp
+++ b/include/boost/dynamic_bitset_fwd.hpp
@@ -16,9 +16,15 @@
 
 namespace boost {
 
+#ifdef BOOST_NO_LONG_LONG
 template <typename Block = unsigned long,
           typename Allocator = std::allocator<Block> >
 class dynamic_bitset;
+#else
+template <typename Block = unsigned long long,
+          typename Allocator = std::allocator<Block> >
+class dynamic_bitset;
+#endif
 
 }
 

--- a/test/dyn_bitset_unit_tests1.cpp
+++ b/test/dyn_bitset_unit_tests1.cpp
@@ -111,7 +111,11 @@ void run_numeric_ctor_tests( BOOST_EXPLICIT_TEMPLATE_TYPE(Tests)
       for (std::size_t n = 0; n < BOOST_BITSET_TEST_COUNT(numbers); ++n ) {
 
           // can match ctor from ulong or templated one
+          #ifdef BOOST_NO_LONG_LONG
           Tests::from_unsigned_long(sizes[s], numbers[n]);
+          #else
+          Tests::from_unsigned_long_long(sizes[s], numbers[n]);
+          #endif
 
           typedef std::size_t compare_type;
           const compare_type sz = sizes[s];
@@ -127,7 +131,11 @@ void run_numeric_ctor_tests( BOOST_EXPLICIT_TEMPLATE_TYPE(Tests)
 
           if (fits) {
             // can match templated ctor only (so we test dispatching)
+            #ifdef BOOST_NO_LONG_LONG
             Tests::from_unsigned_long(static_cast<T>(sizes[s]), numbers[n]);
+            #else
+            Tests::from_unsigned_long_long(static_cast<T>(sizes[s]), numbers[n]);
+            #endif
           }
 
       }
@@ -166,8 +174,13 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
 
     for (std::size_t s = 0; s < BOOST_BITSET_TEST_COUNT(sizes); ++s) {
       for (std::size_t v = 0; v < BOOST_BITSET_TEST_COUNT(values); ++v) {
+          #ifdef BOOST_NO_LONG_LONG
           Tests::from_unsigned_long(sizes[s], values[v]);
           Tests::from_unsigned_long(sizes[s] != 0, values[v]);
+          #else
+          Tests::from_unsigned_long_long(sizes[s], values[v]);
+          Tests::from_unsigned_long_long(sizes[s] != 0, values[v]);
+          #endif
       }
     }
 
@@ -187,7 +200,7 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
     run_numeric_ctor_tests<Tests, unsigned int>();
     run_numeric_ctor_tests<Tests, unsigned long>();
 
-#if defined(BOOST_HAS_LONG_LONG)
+#if !defined(BOOST_NO_LONG_LONG)
     run_numeric_ctor_tests<Tests, ::boost::long_long_type>();
     run_numeric_ctor_tests<Tests, ::boost::ulong_long_type>();
 #endif

--- a/test/dyn_bitset_unit_tests3.cpp
+++ b/test/dyn_bitset_unit_tests3.cpp
@@ -26,6 +26,9 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
 
   std::string long_string = get_long_string();
   std::size_t ul_width = std::numeric_limits<unsigned long>::digits;
+  #ifndef BOOST_NO_LONG_LONG
+  std::size_t ull_width = std::numeric_limits<unsigned long long>::digits;
+  #endif
 
   //=====================================================================
   // Test b.empty()
@@ -43,7 +46,7 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
     Tests::empty(b);
   }
   //=====================================================================
-  // Test b.to_long()
+  // Test b.to_ulong()
   {
     boost::dynamic_bitset<Block> b;
     Tests::to_ulong(b);
@@ -71,6 +74,37 @@ void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
     boost::dynamic_bitset<Block> b(long_string);
     Tests::to_ulong(b);
   }
+  //=====================================================================
+  // Test b.to_ullong()
+  #ifndef BOOST_NO_LONG_LONG
+  {
+      boost::dynamic_bitset<Block> b;
+      Tests::to_ullong(b);
+  }
+  {
+      boost::dynamic_bitset<Block> b(std::string("1"));
+      Tests::to_ullong(b);
+  }
+  {
+      boost::dynamic_bitset<Block> b(bitset_type::bits_per_block,
+                                     static_cast<unsigned long long>(-1));
+      Tests::to_ullong(b);
+  }
+  {
+      std::string str(ull_width - 1, '1');
+      boost::dynamic_bitset<Block> b(str);
+      Tests::to_ullong(b);
+  }
+  {
+      std::string ull_str(ull_width, '1');
+      boost::dynamic_bitset<Block> b(ull_str);
+      Tests::to_ullong(b);
+  }
+  { // case overflow
+      boost::dynamic_bitset<Block> b(long_string);
+      Tests::to_ullong(b);
+  }
+  #endif
   //=====================================================================
   // Test to_string(b, str)
   {


### PR DESCRIPTION
The constructor of std::bitset is unsigned long long since C++11, and a new member function `to_ullong()` has also been added. I know this library needs to be compatible with C++03, but I think it can be solved with the macro `BOOST_NO_LONG_LONG`.
Thanks!