### PR TITLE
Support stateful allocators

### DIFF
--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -730,7 +730,7 @@ dynamic_bitset(dynamic_bitset<Block, Allocator>&& b)
   : m_bits(boost::move(b.m_bits)), m_num_bits(boost::move(b.m_num_bits))
 {
     // Required so that assert(m_check_invariants()); works.
-    assert((b.m_bits = buffer_type()).empty());
+    assert((b.m_bits = buffer_type(get_allocator())).empty());
     b.m_num_bits = 0;
 }
 
@@ -743,7 +743,7 @@ operator=(dynamic_bitset<Block, Allocator>&& b)
     m_bits = boost::move(b.m_bits);
     m_num_bits = boost::move(b.m_num_bits);
     // Required so that assert(m_check_invariants()); works.
-    assert((b.m_bits = buffer_type()).empty());
+    assert((b.m_bits = buffer_type(get_allocator())).empty());
     b.m_num_bits = 0;
     return *this;
 }


### PR DESCRIPTION
If one uses `boost::interprocess::allocator` (or some other stateful allocator) compilation will fail in non-release mode (i.e. `!defined(NDEBUG)`) on two methods of dynamic_bitset (move constructor and move assignment operator). The problematic line is:

```cpp
    // Required so that assert(m_check_invariants()); works.                                                                            
    assert((b.m_bits = buffer_type()).empty());                                     
```

Since construction of `buffer_type` requires an allocator argument. This patch simply passes `get_allocator()` to construct it.