### PR TITLE
Add boolean and equality partial operators

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -25,6 +25,8 @@ test-suite dynamic_bitset :
                                            <library>/boost/system//boost_system ]
     [ run dyn_bitset_unit_tests4.cpp : : : <library>/boost/filesystem//boost_filesystem
                                            <library>/boost/system//boost_system ]
+    [ run dyn_bitset_unit_tests6.cpp : : : <library>/boost/system//boost_system ]
+    [ run dyn_bitset_unit_tests7.cpp : : : <library>/boost/system//boost_system ]
     [ run test_ambiguous_set.cpp ]
     [ run test_lowest_bit.cpp ]
 

--- a/test/dyn_bitset_unit_tests6.cpp
+++ b/test/dyn_bitset_unit_tests6.cpp
@@ -1,0 +1,135 @@
+// -----------------------------------------------------------
+//              Copyright (c) 2001 Jeremy Siek
+//           Copyright (c) 2003-2006 Gennaro Prota
+//             Copyright (c) 2014 Ahmed Charles
+//             Copyright (c) 2018 Evgeny Shulgin
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+// -----------------------------------------------------------
+
+#include "bitset_test.hpp"
+#include <boost/dynamic_bitset/dynamic_bitset.hpp>
+#include <boost/config.hpp>
+
+
+template <typename Block>
+void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
+{
+  typedef boost::dynamic_bitset<Block> bitset_type;
+  typedef bitset_test< bitset_type > Tests;
+  //const int bits_per_block = bitset_type::bits_per_block;
+
+  std::string long_string = get_long_string();
+
+  //=====================================================================
+  // Test operator&=
+  {
+    boost::dynamic_bitset<Block> lhs(3), rhs(4);
+    Tests::and_assignment(lhs, rhs, 0, 0, 3);
+    Tests::and_assignment(lhs, rhs, 0, 1, 3);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(std::string("11")), rhs(std::string("0"));
+    Tests::and_assignment(lhs, rhs, 0, 0, 1);
+    Tests::and_assignment(lhs, rhs, 1, 0, 1);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(long_string.size(), 0), rhs(long_string);
+    Tests::and_assignment(lhs, rhs, 0, 0, long_string.size());
+    Tests::and_assignment(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::and_assignment(lhs, rhs, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(long_string.size(), 1), rhs(long_string);
+    Tests::and_assignment(lhs, rhs, 0, 0, long_string.size());
+    Tests::and_assignment(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::and_assignment(lhs, rhs, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+  //=====================================================================
+  // Test operator |=
+  {
+    boost::dynamic_bitset<Block> lhs(3), rhs(4);
+    Tests::or_assignment(lhs, rhs, 0, 0, 3);
+    Tests::or_assignment(lhs, rhs, 0, 1, 3);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(std::string("11")), rhs(std::string("0"));
+    Tests::or_assignment(lhs, rhs, 0, 0, 1);
+    Tests::or_assignment(lhs, rhs, 1, 0, 1);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(long_string.size(), 0), rhs(long_string);
+    Tests::or_assignment(lhs, rhs, 0, 0, long_string.size());
+    Tests::or_assignment(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::or_assignment(lhs, rhs, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(long_string.size(), 1), rhs(long_string);
+    Tests::or_assignment(lhs, rhs, 0, 0, long_string.size());
+    Tests::or_assignment(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::or_assignment(lhs, rhs, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+  //=====================================================================
+  // Test operator^=
+  {
+    boost::dynamic_bitset<Block> lhs(3), rhs(4);
+    Tests::xor_assignment(lhs, rhs, 0, 0, 3);
+    Tests::xor_assignment(lhs, rhs, 0, 1, 3);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(std::string("11")), rhs(std::string("0"));
+    Tests::xor_assignment(lhs, rhs, 0, 0, 1);
+    Tests::xor_assignment(lhs, rhs, 1, 0, 1);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(std::string("00")), rhs(std::string("1"));
+    Tests::xor_assignment(lhs, rhs, 0, 0, 1);
+    Tests::xor_assignment(lhs, rhs, 1, 0, 1);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(long_string), rhs(long_string);
+    Tests::xor_assignment(lhs, rhs, 0, 0, long_string.size());
+    Tests::xor_assignment(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::xor_assignment(lhs, rhs, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+  //=====================================================================
+  // Test operator-=
+  {
+    boost::dynamic_bitset<Block> lhs(3), rhs(4);
+    Tests::sub_assignment(lhs, rhs, 0, 0, 3);
+    Tests::sub_assignment(lhs, rhs, 0, 1, 3);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(std::string("11")), rhs(std::string("0"));
+    Tests::sub_assignment(lhs, rhs, 0, 0, 1);
+    Tests::sub_assignment(lhs, rhs, 1, 0, 1);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(std::string("00")), rhs(std::string("1"));
+    Tests::sub_assignment(lhs, rhs, 0, 0, 1);
+    Tests::sub_assignment(lhs, rhs, 1, 0, 1);
+  }
+  {
+    boost::dynamic_bitset<Block> lhs(long_string), rhs(long_string);
+    Tests::sub_assignment(lhs, rhs, 0, 0, long_string.size());
+    Tests::sub_assignment(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::sub_assignment(lhs, rhs, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+}
+
+int
+main()
+{
+  run_test_cases<unsigned char>();
+  run_test_cases<unsigned short>();
+  run_test_cases<unsigned int>();
+  run_test_cases<unsigned long>();
+# ifdef BOOST_HAS_LONG_LONG
+  run_test_cases< ::boost::ulong_long_type>();
+# endif
+
+  return boost::report_errors();
+}

--- a/test/dyn_bitset_unit_tests7.cpp
+++ b/test/dyn_bitset_unit_tests7.cpp
@@ -1,0 +1,269 @@
+// -----------------------------------------------------------
+//              Copyright (c) 2001 Jeremy Siek
+//           Copyright (c) 2003-2006 Gennaro Prota
+//             Copyright (c) 2014 Ahmed Charles
+//          Copyright (c) 2014 Riccardo Marcangelo
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+// -----------------------------------------------------------
+
+#include <assert.h>
+#include "bitset_test.hpp"
+#include <boost/dynamic_bitset/dynamic_bitset.hpp>
+#include <boost/limits.hpp>
+#include <boost/config.hpp>
+
+template <typename Block>
+void run_test_cases( BOOST_EXPLICIT_TEMPLATE_TYPE(Block) )
+{
+  // a bunch of typedefs which will be handy later on
+  typedef boost::dynamic_bitset<Block> bitset_type;
+  typedef bitset_test<bitset_type> Tests;
+  // typedef typename bitset_type::size_type size_type; // unusable with Borland 5.5.1
+
+  std::string long_string = get_long_string();
+
+  //=====================================================================
+  // Test intersects
+  {
+    bitset_type a(3); // empty
+    bitset_type b(4);
+    Tests::intersects(a, b, 0, 0, 3);
+    Tests::intersects(a, b, 0, 1, 3);
+  }
+  {
+    bitset_type a(7);
+    bitset_type b(5, 8ul);
+    Tests::intersects(a, b, 0, 0, 5);
+  }
+  {
+    bitset_type a(8, 0ul);
+    bitset_type b(15, 0ul);
+    b[9] = 1;
+    Tests::intersects(a, b, 0, 3, 8);
+  }
+  {
+    bitset_type a(15, 0ul);
+    bitset_type b(22, 0ul);
+    a[14] = b[14] = 1;
+    Tests::intersects(a, b, 0, 1, 14);
+  }
+  {
+    bitset_type a(long_string), b(long_string);
+    b[long_string.size()/2].flip();
+    Tests::intersects(a, b, 0, 0, long_string.size());
+  }
+  {
+    bitset_type a(long_string), b(~a);
+    for(size_t i = 0; i < a.size(); i+= 5)
+    {
+        Tests::intersects(a, b, 0, 0, i);
+        a[i].flip();
+        Tests::intersects(a, b, 0, 0, i);
+        a[i].flip();
+    }
+    
+  }
+  {
+    bitset_type a(long_string), b(a);
+    for(size_t i = 0; i < a.size(); i+= 5)
+    {
+        Tests::intersects(a, b, 0, 0, i);
+        a[i].flip();
+        Tests::intersects(a, b, 0, 0, i);
+        a[i].flip();
+    }
+    
+  }
+  
+  //=====================================================================
+  // Test operator==
+  {
+    bitset_type a(3), b(4);
+    Tests::operator_equal(a, b, 0, 0, 3);
+    Tests::operator_equal(a, b, 0, 1, 3);
+  }
+  {
+    bitset_type a(3), b;
+    Tests::operator_equal(a, b, 0, 0, 0);
+  }
+  {
+    bitset_type a, b(4);
+    Tests::operator_equal(a, b, 0, 0, 0);
+  }
+  {
+    bitset_type a(std::string("00")), b(std::string("0"));
+    Tests::operator_equal(a, b, 0, 0, 1);
+    Tests::operator_equal(a, b, 1, 0, 1);
+  }
+  {
+    bitset_type a(std::string("11")), b(std::string("1"));
+    Tests::operator_equal(a, b, 0, 0, 1);
+    Tests::operator_equal(a, b, 1, 0, 1);
+  }
+  {
+    bitset_type a(long_string), b(long_string);
+    Tests::operator_equal(a, b, 0, 0, long_string.size());
+    Tests::operator_equal(a, b, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+  {
+    bitset_type a(long_string), b(long_string);
+    a[long_string.size()/2].flip();
+    Tests::operator_equal(a, b, 0, 0, long_string.size());
+    Tests::operator_equal(a, b, long_string.size()/2, long_string.size()/2, long_string.size()  - (long_string.size()/2));
+  }
+  {
+    bitset_type a(long_string), b(long_string);
+    b[long_string.size()/2].flip();
+    Tests::operator_equal(a, b, 0, 0, long_string.size());
+    Tests::operator_equal(a, b, long_string.size()/2, long_string.size()/2, long_string.size()  - (long_string.size()/2));
+  }
+  //=====================================================================
+  // Test operator!=
+  {
+    bitset_type a(3), b(4);
+    Tests::operator_not_equal(a, b, 0, 0, 3);
+    Tests::operator_not_equal(a, b, 0, 1, 3);
+  }
+  {
+    bitset_type a(std::string("00")), b(std::string("0"));
+    Tests::operator_not_equal(a, b, 0, 0, 1);
+    Tests::operator_not_equal(a, b, 1, 0, 1);
+  }
+  {
+    bitset_type a(std::string("11")), b(std::string("1"));
+    Tests::operator_not_equal(a, b, 0, 0, 1);
+    Tests::operator_not_equal(a, b, 1, 0, 1);
+  }
+  {
+    bitset_type a(long_string), b(long_string);
+    Tests::operator_not_equal(a, b, 0, 0, long_string.size());
+    Tests::operator_not_equal(a, b, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+  {
+    bitset_type a(long_string), b(long_string);
+    a[long_string.size()/2].flip();
+    Tests::operator_not_equal(a, b, 0, 0, long_string.size());
+    Tests::operator_not_equal(a, b, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+  {
+    bitset_type a(long_string), b(long_string);
+    b[long_string.size()/2].flip();
+    Tests::operator_not_equal(a, b, 0, 0, long_string.size());
+    Tests::operator_not_equal(a, b, long_string.size()/2, long_string.size()/2, long_string.size() - (long_string.size()/2));
+  }
+  //=====================================================================
+  // Test a & b
+  {
+    bitset_type lhs(3), rhs(4);
+    Tests::operator_and(lhs, rhs, 0, 0, 3);
+    Tests::operator_and(lhs, rhs, 0, 1, 3);
+  }
+  {
+    bitset_type lhs(std::string("11")), rhs(std::string("0"));
+    Tests::operator_and(lhs, rhs, 0, 0, 1);
+    Tests::operator_and(lhs, rhs, 1, 0, 1);
+  }
+  {
+    bitset_type lhs(long_string.size(), 0), rhs(long_string);
+    Tests::operator_and(lhs, rhs, 0, 0, long_string.size()/2);
+    Tests::operator_and(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::operator_and(lhs, rhs, long_string.size()/2, 0, long_string.size() - (long_string.size()/2));
+  }
+  {
+    bitset_type lhs(long_string.size(), 1), rhs(long_string);
+    Tests::operator_and(lhs, rhs, 0, 0, long_string.size()/2);
+    Tests::operator_and(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::operator_and(lhs, rhs, long_string.size()/2, 0, long_string.size() - (long_string.size()/2));
+  }
+  //=====================================================================
+  // Test a | b
+  {
+    bitset_type lhs(3), rhs(4);
+    Tests::operator_or(lhs, rhs, 0, 0, 3);
+    Tests::operator_or(lhs, rhs, 0, 1, 3);
+  }
+  {
+    bitset_type lhs(std::string("11")), rhs(std::string("0"));
+    Tests::operator_or(lhs, rhs, 0, 0, 1);
+    Tests::operator_or(lhs, rhs, 1, 0, 1);
+  }
+  {
+    bitset_type lhs(long_string.size(), 0), rhs(long_string);
+    Tests::operator_or(lhs, rhs, 0, 0, long_string.size()/2);
+    Tests::operator_or(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::operator_or(lhs, rhs, long_string.size()/2, 0, long_string.size() - (long_string.size()/2));
+  }
+  {
+    bitset_type lhs(long_string.size(), 1), rhs(long_string);
+    Tests::operator_or(lhs, rhs, 0, 0, long_string.size()/2);
+    Tests::operator_or(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::operator_or(lhs, rhs, long_string.size()/2, 0, long_string.size() - (long_string.size()/2));
+  }
+  //=====================================================================
+  // Test a^b
+  {
+    bitset_type lhs(3), rhs(4);
+    Tests::operator_xor(lhs, rhs, 0, 0, 3);
+    Tests::operator_xor(lhs, rhs, 0, 1, 3);
+  }
+  {
+    bitset_type lhs(std::string("11")), rhs(std::string("0"));
+    Tests::operator_xor(lhs, rhs, 0, 0, 1);
+    Tests::operator_xor(lhs, rhs, 1, 0, 1);
+  }
+  {
+    bitset_type lhs(long_string.size(), 0), rhs(long_string);
+    Tests::operator_xor(lhs, rhs, 0, 0, long_string.size()/2);
+    Tests::operator_xor(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::operator_xor(lhs, rhs, long_string.size()/2, 0, long_string.size() - (long_string.size()/2));
+  }
+  {
+    bitset_type lhs(long_string.size(), 1), rhs(long_string);
+    Tests::operator_xor(lhs, rhs, 0, 0, long_string.size()/2);
+    Tests::operator_xor(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::operator_xor(lhs, rhs, long_string.size()/2, 0, long_string.size() - (long_string.size()/2));
+  }
+  //=====================================================================
+  // Test a-b
+  {
+    bitset_type lhs(3), rhs(4);
+    Tests::operator_sub(lhs, rhs, 0, 0, 3);
+    Tests::operator_sub(lhs, rhs, 0, 1, 3);
+  }
+  {
+    bitset_type lhs(std::string("11")), rhs(std::string("0"));
+    Tests::operator_sub(lhs, rhs, 0, 0, 1);
+    Tests::operator_sub(lhs, rhs, 1, 0, 1);
+  }
+  {
+    bitset_type lhs(long_string.size(), 0), rhs(long_string);
+    Tests::operator_sub(lhs, rhs, 0, 0, long_string.size()/2);
+    Tests::operator_sub(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::operator_sub(lhs, rhs, long_string.size()/2, 0, long_string.size() - (long_string.size()/2));
+  }
+  {
+    bitset_type lhs(long_string.size(), 1), rhs(long_string);
+    Tests::operator_sub(lhs, rhs, 0, 0, long_string.size()/2);
+    Tests::operator_sub(lhs, rhs, 1, 2, long_string.size() - 2);
+    Tests::operator_sub(lhs, rhs, long_string.size()/2, 0, long_string.size() - (long_string.size()/2));
+  }
+}
+
+
+int
+main()
+{
+  run_test_cases<unsigned char>();
+  run_test_cases<unsigned short>();
+  run_test_cases<unsigned int>();
+  run_test_cases<unsigned long>();
+# ifdef BOOST_HAS_LONG_LONG
+  run_test_cases< ::boost::ulong_long_type>();
+# endif
+
+  return boost::report_errors();
+}


### PR DESCRIPTION
Create boolean (or, and, xor and sub) and equality operators, that operate on two distinct bitsets with different starting points, but same length. Use the partial view as the base object for the partial operations.