### PR TITLE
docs: retry ui-bundle downloads

### DIFF
--- a/doc/local-playbook.yml
+++ b/doc/local-playbook.yml
@@ -22,7 +22,7 @@ content:
   sources:
     - url: ..
       start_path: doc
-      edit_url: 'https://github.com/boostorg/dynamic_bitset/edit/{refname}/{path}'
+      edit_url: 'https://github.com/boostorg/dynamic_bitset/edit/develop/{path}'
 
 output:
   dir: html
@@ -47,6 +47,7 @@ antora:
           tag: 'develop'
           variable: 'BOOST_SRC_DIR'
           system-env: 'BOOST_SRC_DIR'
+    - require: '@cppalliance/antora-downloads-extension'
 
 asciidoc:
   attributes:

--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -11,6 +11,7 @@
         "@asciidoctor/tabs": "^1.0.0-beta.3",
         "@cppalliance/antora-cpp-reference-extension": "^0.0.8",
         "@cppalliance/antora-cpp-tagfiles-extension": "^0.0.5",
+        "@cppalliance/antora-downloads-extension": "^0.0.2",
         "@cppalliance/asciidoctor-boost-links": "^0.0.2"
       },
       "devDependencies": {
@@ -438,6 +439,12 @@
         "he": "^1.2.0",
         "isomorphic-git": "^1.33.2"
       }
+    },
+    "node_modules/@cppalliance/antora-downloads-extension": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@cppalliance/antora-downloads-extension/-/antora-downloads-extension-0.0.2.tgz",
+      "integrity": "sha512-2wXahlvRz9J75ZSfzDeP4XpIZiqIm+w/YjmCWJxFPp6oWgP7e8f6ps7HqdtHNGxnK5mG38OjiCFdHjmHYfgbDA==",
+      "license": "BSL-1.0"
     },
     "node_modules/@cppalliance/asciidoctor-boost-links": {
       "version": "0.0.2",

--- a/doc/package.json
+++ b/doc/package.json
@@ -10,6 +10,7 @@
     "@asciidoctor/tabs": "^1.0.0-beta.3",
     "@cppalliance/antora-cpp-reference-extension": "^0.0.8",
     "@cppalliance/antora-cpp-tagfiles-extension": "^0.0.5",
+    "@cppalliance/antora-downloads-extension": "^0.0.2",
     "@cppalliance/asciidoctor-boost-links": "^0.0.2"
   }
 }


### PR DESCRIPTION
Any download during a CI build might potentially fail so it's convenient to retry. This PR includes a new extension "@cppalliance/antora-downloads-extension" with a retry loop for the ui-bundle.