### PR TITLE
Loosen the private access specifier to protected

### DIFF
--- a/include/boost/dynamic_bitset/dynamic_bitset.hpp
+++ b/include/boost/dynamic_bitset/dynamic_bitset.hpp
@@ -1339,7 +1339,7 @@ public:
     class serialize_impl;
     friend class serialize_impl;
 
-private:
+protected:
     static constexpr int                              ulong_width = std::numeric_limits< unsigned long >::digits;
 
     BOOST_DYNAMIC_BITSET_CONSTEXPR20 dynamic_bitset & range_operation( size_type pos, size_type len, Block ( *partial_block_operation )( Block, size_type, size_type ), Block ( *full_block_operation )( Block ) );


### PR DESCRIPTION
Allows derived classes to access the underlying storage directly.

For derived classes, it can be useful to access the underlying storage (`m_bits`) when adding customized optimized accessors. Before Boost 1.90, this could be hacked around by BOOST_DYNAMIC_BITSET_DONT_USE_FRIENDS, which is not possible anymore. I understand the internals should not be public, but I think it makes sense to change `private:` to `protected:` so the class can be easily extended.